### PR TITLE
Add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @GalactusPlatform/genesys-devs


### PR DESCRIPTION
This pull request includes a small change to the `.github/CODEOWNERS` file. The change assigns all files to the `@GalactusPlatform/genesys-devs` team for ownership.