### PR TITLE
[acm] added alt name wildcard to include account slug (#14)

### DIFF
--- a/aws/modules/acm/main.tf
+++ b/aws/modules/acm/main.tf
@@ -3,6 +3,10 @@ resource "aws_acm_certificate" "cert" {
   domain_name       = "*.${var.domain_name}"
   validation_method = "DNS"
 
+  subject_alternative_names = [
+    "*.${var.account}.${var.domain_name}"
+  ]
+
   lifecycle {
     create_before_destroy = true
   }


### PR DESCRIPTION
This pull request includes a small but important change to the `aws/modules/acm/main.tf` file. The change adds subject alternative names to the `aws_acm_certificate` resource to include the account name in the domain.

* [`aws/modules/acm/main.tf`](diffhunk://#diff-ab46fdd626542d98ea98cff53730360992110acab9523ec411f450aff96fb0e2R6-R9): Added `subject_alternative_names` to the `aws_acm_certificate` resource to include `*.<account>.<domain_name>`.